### PR TITLE
Update 67053888672aef.md

### DIFF
--- a/articles/67053888672aef.md
+++ b/articles/67053888672aef.md
@@ -39,8 +39,7 @@ generator client {
 datasource db {
     provider          = "postgresql"
     url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
-    directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
+    directUrl         = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 model Account {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.

私はGoogle翻訳を使用しました。 翻訳が悪くてごめんなさい。

`shadowDatabaseUrl` は Vercel Postgres には必要なくなりました。`directUrl` と同じ値に設定すると問題が発生する可能性があります。